### PR TITLE
Fix: Use st.download_button for robust HTML report downloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -282,11 +282,15 @@ def display_results(results, report, report_generator):
             )
         
         with col2:
-            if st.button("📄 Download HTML Report"):
-                html_report = report_generator.export_report(report, format_type='html')
-                b64 = base64.b64encode(html_report.encode()).decode()
-                href = f'<a href="data:text/html;base64,{b64}" download="accessibility_report.html">Download HTML Report</a>'
-                st.markdown(href, unsafe_allow_html=True)
+            # Prepare data for HTML download first
+            html_report = report_generator.export_report(report, format_type='html')
+            # Then display the download button
+            st.download_button(
+                label="📄 Download HTML Report",
+                data=html_report,
+                file_name="accessibility_report.html",
+                mime="text/html",
+            )
 
 def display_automated_results(automated_results):
     """Display automated testing results from axe-core"""


### PR DESCRIPTION
This commit addresses an issue where the 'Download HTML Report' button was not working. The problem was that the HTML download mechanism still used the st.button + st.markdown(data_uri) pattern, which can fail for larger HTML content due to browser URL length limitations.

This was missed during a previous refactoring of the HTML report generation logic, where only the source of the HTML string was updated, not the download mechanism itself.

This commit replaces the st.markdown approach with st.download_button for the HTML report download. This aligns it with the JSON download mechanism and uses Streamlit's more robust method for handling file downloads.