### PR TITLE
Fix: Preserve results display after download button clicks

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,14 @@ def main():
         initial_sidebar_state="expanded"
     )
     
+    # Initialize session state variables if not already present
+    if 'results' not in st.session_state:
+        st.session_state.results = None
+    if 'report' not in st.session_state:
+        st.session_state.report = None
+    if 'report_generator' not in st.session_state:
+        st.session_state.report_generator = None
+
     st.title("♿ WCAG Accessibility Evaluator")
     st.markdown("""
     This tool provides comprehensive web accessibility evaluation combining automated axe-core testing 
@@ -162,8 +170,15 @@ def main():
             progress_bar.progress(100)
             status_text.text("Analysis complete!")
             
+            # Store results in session state
+            st.session_state.results = results
+            st.session_state.report = report
+            st.session_state.report_generator = report_generator
+
             # Display results
-            display_results(results, report, report_generator)
+            # Using session state here ensures consistency if display_results is ever called
+            # from outside this immediate analysis block in the future.
+            display_results(st.session_state.results, st.session_state.report, st.session_state.report_generator)
             
         except Exception as e:
             print(e)
@@ -171,9 +186,13 @@ def main():
             raise Exception(f"Error during axe-core analysis: {str(e)}")
             progress_bar.empty()
             status_text.empty()
+    elif st.session_state.report is not None:
+        # This handles reruns where results already exist in session state
+        # (e.g., after a download button click or other widget interaction)
+        display_results(st.session_state.results, st.session_state.report, st.session_state.report_generator)
     
-    # Display example or help information
-    if not url:
+    # Display example or help information only if no URL is entered and no report is in session
+    if not url and st.session_state.report is None:
         st.markdown("---")
         st.subheader("How it works")
         


### PR DESCRIPTION
This commit addresses an issue where analysis results would disappear, and the application would revert to its initial state after clicking either the 'Download JSON Report' or 'Download HTML Report' button.

The root cause was that clicking these buttons triggered a Streamlit script rerun, but the application state (the generated 'results' and 'report' objects) was not being preserved across these reruns.

Changes implemented:
- Initialize `st.session_state.results`, `st.session_state.report`, and `st.session_state.report_generator` to `None` at the start of the application if they are not already set.
- After a successful analysis, store the generated `results`, `report`, and the `report_generator` instance in `st.session_state`.
- Modified the main application logic to check `st.session_state` on reruns. If a report exists in the session state, the application now retrieves and displays these persisted results, even if the rerun was triggered by a download button and not a new analysis.
- Adjusted the visibility condition for the initial "How it works" section to prevent it from showing if results are being displayed.

These changes ensure that the analysis results remain visible after downloading a report, providing a more consistent experience for you.